### PR TITLE
Config link and isset check.

### DIFF
--- a/pantheon_domain_masking.info.yml
+++ b/pantheon_domain_masking.info.yml
@@ -3,3 +3,4 @@ type: module
 description: 'Support for domain masking on Pantheon sites'
 core: 8.x
 package: 'Pantheon'
+configure: pantheon_domain_masking.domain_masking_config_form

--- a/src/Form/DomainMaskingConfigForm.php
+++ b/src/Form/DomainMaskingConfigForm.php
@@ -105,8 +105,8 @@ class DomainMaskingConfigForm extends ConfigFormBase {
     }
 
 
-    $pantheonEnv = $_ENV['PANTHEON_ENVIRONMENT'] ?: '[env]';
-    $pantheonSiteName = $_ENV['PANTHEON_SITE_NAME'] ?: '[site-name]';
+    $pantheonEnv = isset($_ENV['PANTHEON_ENVIRONMENT']) ?: '[env]';
+    $pantheonSiteName = isset($_ENV['PANTHEON_SITE_NAME']) ?: '[site-name]';
     $form['allow_platform'] = [
       '#type' => 'radios',
       '#title' => $this->t('Allow Platform domain access?'),


### PR DESCRIPTION
Add config link to module listing and check that $_ENV['PANTHEON_SITE_NAME'] & $_ENV['PANTHEON_ENVIRONMENT'] is set to avoid warnings on install.