### PR TITLE
Fix notices about missing PANTHEON_ ENV vars

### DIFF
--- a/src/Form/DomainMaskingConfigForm.php
+++ b/src/Form/DomainMaskingConfigForm.php
@@ -105,8 +105,8 @@ class DomainMaskingConfigForm extends ConfigFormBase {
     }
 
 
-    $pantheonEnv = $_ENV['PANTHEON_ENVIRONMENT'] ?: '[env]';
-    $pantheonSiteName = $_ENV['PANTHEON_SITE_NAME'] ?: '[site-name]';
+    $pantheonEnv = $_ENV['PANTHEON_ENVIRONMENT'] ?? '[env]';
+    $pantheonSiteName = $_ENV['PANTHEON_SITE_NAME'] ?? '[site-name]';
     $form['allow_platform'] = [
       '#type' => 'radios',
       '#title' => $this->t('Allow Platform domain access?'),


### PR DESCRIPTION
This replaces the ternary operator with the Null Coalescing Operator (introduced in PHP 7) to initialize variables without an error/notice, even if the Pantheon variables are not available in the environment.