### PR TITLE
Use configurable header values to determine platform access

### DIFF
--- a/src/Form/DomainMaskingConfigForm.php
+++ b/src/Form/DomainMaskingConfigForm.php
@@ -105,6 +105,39 @@ class DomainMaskingConfigForm extends ConfigFormBase {
     }
 
 
+// use this to determine platform access
+    $form['header'] = [
+      '#type' => 'textfield',
+      '#length' => 255,
+      '#title' => $this->t('Request Header'),
+      '#description' => $this->t('Request header used to determine if the request is on-platform or not.'),
+      '#default_value' => $configEditable->get('header'),
+    ];
+    // Check overrides.
+    if ($configEditable->get('header') !== $configOverridden->get('header')) {
+      $form['header']['#disabled'] = TRUE;
+      $form['header']['#description'] .= $this->t(' **This config value has been overridden in code and cannot be changed here. The value that is shown is the actual value in use.**');
+      $form['header']['#default_value'] = $configOverridden->get('header');
+    }
+
+    $form['matchvalue'] = [
+      '#type' => 'textfield',
+      '#length' => 255,
+      '#title' => $this->t('Header Value'),
+      '#description' => $this->t('When the header above matches this value, the request will be considered masked and non-platform.'),
+      '#default_value' => $configEditable->get('matchvalue'),
+    ];
+    // Check overrides.
+    if ($configEditable->get('matchvalue') !== $configOverridden->get('matchvalue')) {
+      $form['matchvalue']['#disabled'] = TRUE;
+      $form['matchvalue']['#description'] .= $this->t(' **This config value has been overridden in code and cannot be changed here. The value that is shown is the actual value in use.**');
+      $form['matchvalue']['#default_value'] = $configOverridden->get('matchvalue');
+    }
+
+
+
+
+
     $pantheonEnv = $_ENV['PANTHEON_ENVIRONMENT'] ?? '[env]';
     $pantheonSiteName = $_ENV['PANTHEON_SITE_NAME'] ?? '[site-name]';
     $form['allow_platform'] = [
@@ -155,6 +188,8 @@ class DomainMaskingConfigForm extends ConfigFormBase {
       ->set('subpath', $form_state->getValue('subpath', NULL))
       ->set('enabled', $form_state->getValue('enabled'))
       ->set('allow_platform', $form_state->getValue('allow_platform'))
+      ->set('header', $form_state->getValue('header'))
+      ->set('matchvalue', $form_state->getValue('matchvalue'))
       ->save();
   }
 

--- a/src/Middleware/DomainMaskingMiddleware.php
+++ b/src/Middleware/DomainMaskingMiddleware.php
@@ -56,7 +56,6 @@ class DomainMaskingMiddleware implements HttpKernelInterface {
 
       // First check to see if we're even enabled.
       $enabled = \filter_var($config->get('enabled', 'no'), FILTER_VALIDATE_BOOLEAN);
-
       if ($enabled === TRUE) {
         $mask = TRUE;
 
@@ -67,7 +66,7 @@ class DomainMaskingMiddleware implements HttpKernelInterface {
         // allow platform domains, don't mask.
         if ($this->isPlatformDomainRequest()) {
           $allowPlatform = \filter_var($config->get('allow_platform', 'no'), FILTER_VALIDATE_BOOLEAN);
-          if ($allowPlatform === TRUE) {
+          if ($allowPlatform == TRUE) {
             $mask = FALSE;
           }
         }
@@ -130,9 +129,14 @@ class DomainMaskingMiddleware implements HttpKernelInterface {
    * @return boolean
    */
   protected function isPlatformDomainRequest(Request $request = NULL) {
+    $config = $this->configFactory->get('pantheon_domain_masking.settings');
+
+    $headername = $config->get('header', 'adv-cdn-origin');
+    $headervalue = $config->get('matchvalue', '1');
     $targetReq = $request ?: $this->origRequest;
+
     if ($targetReq) {
-      if ($targetReq->headers->has('adv-cdn-origin') && $targetReq->headers->get('adv-cdn-origin', '0') == 1) {
+      if ($targetReq->headers->has($headername) && $targetReq->headers->get($headername, '0') == $headervalue) {
         return FALSE;
       }
       else {


### PR DESCRIPTION
Add configuration options to determine the header values to use for platform access.

Some Pantheon customers will be managing their own proxy and will not be able to use the 'adv-cdn-origin' header
(for example, IIS is unable to add request header). For situations like this, using a different header, such as
the Host header will make more sense for determining whether the request is on/off platform.

The two configuration keys 'header' and 'matchvalue' are defaulted to 'adv-cdn-origin' and '1' to maintain downward
compatibility with existing implementations using this module without those configurations.