### PR TITLE
Redirect URLs from platform domain if the subpath are hardcoded or cached

### DIFF
--- a/src/Middleware/DomainMaskingMiddleware.php
+++ b/src/Middleware/DomainMaskingMiddleware.php
@@ -81,11 +81,12 @@ class DomainMaskingMiddleware implements HttpKernelInterface {
               if (strpos($current_request['REQUEST_URI'], $subpath) > 0) {
                 // If subpath is found, remove it from the URL via Redirect
                 $new_path =  str_replace( "/{$subpath}", "", $current_request['REQUEST_URI']);
-
-        				$proto = 'https';
-        				if (isset($_SERVER['HTTP_USER_AGENT_HTTPS']) && $_SERVER['HTTP_USER_AGENT_HTTPS'] != 'ON') {
+                
+                $proto = 'https';
+                if (isset($_SERVER['HTTP_USER_AGENT_HTTPS']) && $_SERVER['HTTP_USER_AGENT_HTTPS'] != 'ON') {
                   $proto = 'http';
                 }
+                
                 $redirect_url = "{$proto}://" . $current_request['HTTP_HOST'] . $new_path;
                 $redirect = new RedirectResponse($redirect_url);
                 $redirect->send();

--- a/src/Middleware/DomainMaskingMiddleware.php
+++ b/src/Middleware/DomainMaskingMiddleware.php
@@ -87,8 +87,8 @@ class DomainMaskingMiddleware implements HttpKernelInterface {
                   $proto = 'http';
                 }
                 $redirect_url = "{$proto}://" . $current_request['HTTP_HOST'] . $new_path;
-        				$redirect = new RedirectResponse($redirect_url);
-        				$redirect->send();
+                $redirect = new RedirectResponse($redirect_url);
+                $redirect->send();
               }
             }
           }

--- a/src/Middleware/DomainMaskingMiddleware.php
+++ b/src/Middleware/DomainMaskingMiddleware.php
@@ -71,6 +71,26 @@ class DomainMaskingMiddleware implements HttpKernelInterface {
           $allowPlatform = \filter_var($config->get('allow_platform', 'no'), FILTER_VALIDATE_BOOLEAN);
           if ($allowPlatform === TRUE) {
             $mask = FALSE;
+
+            $subpath = $config->get('subpath', '');            
+            if (!empty($subpath)) {
+              
+              $current_request = $request->server->all();
+              
+              // Check if subpath is found on the URL
+              if (strpos($current_request['REQUEST_URI'], $subpath) > 0) {
+                // If subpath is found, remove it from the URL via Redirect
+                $new_path =  str_replace( "/{$subpath}", "", $current_request['REQUEST_URI']);
+
+        				$proto = 'https';
+        				if (isset($_SERVER['HTTP_USER_AGENT_HTTPS']) && $_SERVER['HTTP_USER_AGENT_HTTPS'] != 'ON') {
+                  $proto = 'http';
+                }
+                $redirect_url = "{$proto}://" . $current_request['HTTP_HOST'] . $new_path;
+        				$redirect = new RedirectResponse($redirect_url);
+        				$redirect->send();
+              }
+            }
           }
         }
 


### PR DESCRIPTION
**Background:**
As discovered with Drupal 10, a regression is found that causes CSS and JS aggregated URLs have a fixed URL path and is not affected by cache contexts: https://www.drupal.org/project/drupal/issues/3354204,

As a workaround for this issue, we apply a workaround in the target subpath site to redirect URLs if the sub-path site is detected when accessing the platform domain URL

With this, we also apply a solution for potential URLs where the subpath was added incorrectly to via content or caching

_Note:
There is a special counterpart AGCDN configuration that is done by Pantheon to apply a similar redirect when URLs are also missing the subpath prefix but it was actually a CSS or JS file rendered from a subpath site._