### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@pantheon-systems/implementation-team
+* @pantheon-systems/implementation-team


### PR DESCRIPTION
The CODEOWNERS file did not follow the expected syntax. Github expects each entry to be a path (e.g. `*`) followed by a user or a team. The path was missing.