### PR TITLE
Add multilingual subpath support via PathProcessor

### DIFF
--- a/config/install/pantheon_domain_masking.settings.yml
+++ b/config/install/pantheon_domain_masking.settings.yml
@@ -2,3 +2,4 @@ domain: "example.com"
 enabled: 'no'
 allow_platform: 'yes'
 subpath: ''
+multilingual: 'no'

--- a/pantheon_domain_masking.services.yml
+++ b/pantheon_domain_masking.services.yml
@@ -4,6 +4,14 @@ services:
     arguments: ['@config.factory']
     tags:
       - { name: http_middleware, priority: 400 }
+  pantheon_domain_masking.subpath_path_processor:
+    class: Drupal\pantheon_domain_masking\PathProcessor\SubpathPathProcessor
+    arguments: ['@config.factory']
+    tags:
+      # Inbound: strip subpath before language processor (language runs at 300).
+      - { name: path_processor_inbound, priority: 400 }
+      # Outbound: add subpath after language processor (language runs at 100).
+      - { name: path_processor_outbound, priority: 50 }
   pantheon_domain_masking.helper:
     class: Drupal\pantheon_domain_masking\Helper
     arguments: ['@config.factory', '@request_stack']

--- a/src/Middleware/DomainMaskingMiddleware.php
+++ b/src/Middleware/DomainMaskingMiddleware.php
@@ -88,8 +88,14 @@ class DomainMaskingMiddleware implements HttpKernelInterface {
 
           // Can't do subpaths without domain masking.
           $subpath = $config->get('subpath');
-          if (!empty($subpath)) {
-            // More cookie jawn.
+          $multilingual = \filter_var($config->get('multilingual'), FILTER_VALIDATE_BOOLEAN);
+
+          if (!empty($subpath) && !$multilingual) {
+            // Standard (non-multilingual) subpath handling: modify server
+            // variables so Symfony's Request derives the correct base path.
+            // When multilingual mode is enabled, SubpathPathProcessor handles
+            // subpath stripping/adding instead, to properly coordinate with
+            // Drupal's language path prefix negotiation.
             ini_set('session.cookie_path', "/{$subpath}");
 
             // Add the subpath back into the request, if not already present.
@@ -117,8 +123,16 @@ class DomainMaskingMiddleware implements HttpKernelInterface {
           if (isset($_SERVER['HTTP_USER_AGENT_HTTPS']) && $_SERVER['HTTP_USER_AGENT_HTTPS'] != 'ON') {
             $proto = 'http';
           }
-          $base_path = "/{$subpath}";
-          $base_url = $base_root = "{$proto}://{$host}" . (empty($subpath) ? '' : "/{$subpath}");
+          if ($multilingual) {
+            // In multilingual mode, SubpathPathProcessor handles the subpath
+            // in the path processing pipeline. Base path stays at root.
+            $base_path = '/';
+            $base_url = $base_root = "{$proto}://{$host}";
+          }
+          else {
+            $base_path = "/{$subpath}";
+            $base_url = $base_root = "{$proto}://{$host}" . (empty($subpath) ? '' : "/{$subpath}");
+          }
           $GLOBALS['base_path'] = $base_path;
           $GLOBALS['base_url'] = $base_url;
           $GLOBALS['base_root'] = $base_root;

--- a/src/PathProcessor/SubpathPathProcessor.php
+++ b/src/PathProcessor/SubpathPathProcessor.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Drupal\pantheon_domain_masking\PathProcessor;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\PathProcessor\InboundPathProcessorInterface;
+use Drupal\Core\PathProcessor\OutboundPathProcessorInterface;
+use Drupal\Core\Render\BubbleableMetadata;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Processes inbound/outbound paths for domain masking with multilingual support.
+ *
+ * When domain masking uses a subpath (e.g., /ca-en) AND the site uses Drupal's
+ * language negotiation via URL path prefix (e.g., /fr, /en), the subpath must
+ * be stripped/added at the correct point in the path processing pipeline:
+ *
+ * Inbound:  /ca-en/fr/page → strip /ca-en → /fr/page → language strips /fr → /page
+ * Outbound: /page → language adds /fr → /fr/page → add /ca-en → /ca-en/fr/page
+ *
+ * This processor runs at higher priority than the language processor for inbound
+ * (so subpath is stripped first) and lower priority for outbound (so subpath is
+ * added after the language prefix).
+ *
+ * Activated by setting 'multilingual' to TRUE in the module configuration:
+ *   $config['pantheon_domain_masking.settings']['multilingual'] = TRUE;
+ */
+class SubpathPathProcessor implements InboundPathProcessorInterface, OutboundPathProcessorInterface {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a new SubpathPathProcessor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processInbound($path, Request $request) {
+    $subpath = $this->getActiveSubpath($request);
+    if ($subpath === NULL) {
+      return $path;
+    }
+
+    $prefix = '/' . $subpath;
+
+    // Strip the subpath prefix from the beginning of the path.
+    if ($path === $prefix) {
+      return '/';
+    }
+    if (str_starts_with($path, $prefix . '/')) {
+      return substr($path, strlen($prefix));
+    }
+
+    return $path;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processOutbound($path, &$options = [], Request $request = NULL, BubbleableMetadata $bubbleable_metadata = NULL) {
+    $subpath = $this->getActiveSubpath($request);
+    if ($subpath === NULL) {
+      return $path;
+    }
+
+    $prefix = '/' . $subpath;
+
+    // Don't double-prefix.
+    if (str_starts_with($path, $prefix . '/') || $path === $prefix) {
+      return $path;
+    }
+
+    return $prefix . $path;
+  }
+
+  /**
+   * Returns the active subpath if multilingual mode is enabled.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request|null $request
+   *   The current request, if available.
+   *
+   * @return string|null
+   *   The subpath string (without leading slash), or NULL if inactive.
+   */
+  protected function getActiveSubpath(?Request $request): ?string {
+    $config = $this->configFactory->get('pantheon_domain_masking.settings');
+
+    // Only active when multilingual mode is explicitly enabled.
+    if (!\filter_var($config->get('multilingual'), FILTER_VALIDATE_BOOLEAN)) {
+      return NULL;
+    }
+
+    // Only active when masking is enabled and this is not a platform request.
+    if (!\filter_var($config->get('enabled'), FILTER_VALIDATE_BOOLEAN)) {
+      return NULL;
+    }
+
+    $subpath = $config->get('subpath');
+    if (empty($subpath)) {
+      return NULL;
+    }
+
+    // On platform domain requests (no adv-cdn-origin header), skip subpath
+    // processing since there is no subpath in the URL.
+    if ($request) {
+      $isPlatform = !($request->headers->has('adv-cdn-origin')
+        && $request->headers->get('adv-cdn-origin', '0') == 1);
+      if ($isPlatform) {
+        $allowPlatform = \filter_var($config->get('allow_platform'), FILTER_VALIDATE_BOOLEAN);
+        if ($allowPlatform) {
+          return NULL;
+        }
+      }
+    }
+
+    return $subpath;
+  }
+
+}


### PR DESCRIPTION
## Summary

- Adds `SubpathPathProcessor` implementing both `InboundPathProcessorInterface` and `OutboundPathProcessorInterface`
- New `multilingual` config option (default: `'no'`) — when enabled, subpath handling moves from the middleware's SCRIPT_NAME approach to Drupal's PathProcessor pipeline
- Middleware skips SCRIPT_NAME/base_path modification when multilingual mode is active

## Problem

When domain masking uses a subpath (e.g., `/ca-en`) on a Drupal site with language negotiation via URL path prefix (`/en`, `/fr`), the middleware's existing approach of modifying `SCRIPT_NAME` and `$GLOBALS['base_path']` does not properly integrate with Drupal's language path processor pipeline.

**Example:** `www.nemluvio.com/ca-en/fr/gps` arrives at Drupal as `/ca-en/fr/gps/`. The language negotiation processor expects the language prefix (`/fr`) at the start of the path, but instead sees `/ca-en` as the first segment — language detection fails and the page 404s.

## How it works

**Inbound** (priority 400, before language at 300):
```
/ca-en/fr/page → SubpathPathProcessor strips /ca-en → /fr/page → LanguageNegotiationUrl strips /fr → /page
```

**Outbound** (priority 50, after language at 100):
```
/page → LanguageNegotiationUrl adds /fr → /fr/page → SubpathPathProcessor adds /ca-en → /ca-en/fr/page
```

## Usage

In `settings.php`:
```php
$config['pantheon_domain_masking.settings']['multilingual'] = TRUE;
$config['pantheon_domain_masking.settings']['subpath'] = ltrim($_SERVER["HTTP_X_MASKED_PATH"] ?? '', '/');
```

## Test plan

- [ ] Verify `/ca-en/gps` returns 200 (English, no language prefix)
- [ ] Verify `/ca-en/fr/gps` returns 200 with `x-drupal-language: fr`
- [ ] Verify `/ca-en/en/gps` returns 200 with `x-drupal-language: en`
- [ ] Verify outbound links include `/ca-en/` prefix before language prefix
- [ ] Verify language switcher generates correct URLs (`/ca-en/fr/...`, `/ca-en/en/...`)
- [ ] Verify asset URLs (CSS, JS, images) resolve correctly through domain mask
- [ ] Verify platform domain access (pantheonsite.io) still works without subpath processing
- [ ] Verify `multilingual: 'no'` (default) preserves existing behavior