### PR TITLE
DELENG-435: Add catalog-info.yaml for service catalog onboarding

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: pantheon_domain_masking
+  description: Domain Masking helper module for D8+
+  annotations:
+    github.com/project-slug: pantheon-systems/pantheon_domain_masking
+spec:
+  type: service
+  lifecycle: production
+  owner: implementation-team


### PR DESCRIPTION
## Summary
Adds `catalog-info.yaml` to enable service catalog integration per [Onboarding to The Catalog](https://getpantheon.atlassian.net/wiki/spaces/Catalog/pages/3284434948/Onboarding+to+The+Catalog) documentation.

## Changes
- **Added `catalog-info.yaml`** with the following metadata:
  - **Owner:** `implementation-team`
  - **Lifecycle:** `production`
  - **Type:** `service`

## How Owner Was Determined
- **CODEOWNERS teams:** `implementation-team`
- **Catalog owner:** `implementation-team`

## How Lifecycle Was Determined
- Set to `production` based on repository criticality assessment
- Valid options: `experimental`, `mature`, `deprecated` (per catalog documentation)

## Testing
- [ ] Verify catalog-info.yaml syntax is valid
- [ ] Confirm owner team exists in GitHub
- [ ] Check that lifecycle value is valid

## Related
- Jira: [DELENG-435](https://getpantheon.atlassian.net/browse/DELENG-435)
- Part of Repository Ownership Initiative
- Follows [Catalog Onboarding Guide](https://getpantheon.atlassian.net/wiki/spaces/Catalog/pages/3284434948/Onboarding+to+The+Catalog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DELENG-435]: https://getpantheon.atlassian.net/browse/DELENG-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ