### PR TITLE
Added fix for subpath prefix overlap issue.

### DIFF
--- a/src/Middleware/DomainMaskingMiddleware.php
+++ b/src/Middleware/DomainMaskingMiddleware.php
@@ -97,12 +97,29 @@ class DomainMaskingMiddleware implements HttpKernelInterface {
             if (!str_starts_with((string) $newRequestArray['SCRIPT_NAME'], "/{$subpath}/")) {
               $newRequestArray['SCRIPT_NAME'] = "/{$subpath}" . $newRequestArray['SCRIPT_NAME'];
             }
-            if (!str_starts_with((string) $newRequestArray['REQUEST_URI'], "/{$subpath}")) {
+            if (
+              !str_starts_with((string) $newRequestArray['REQUEST_URI'], "/{$subpath}/") &&
+              $newRequestArray['REQUEST_URI'] !== "/{$subpath}"
+            ) {
               $newRequestArray['REQUEST_URI'] = "/{$subpath}" . $newRequestArray['REQUEST_URI'];
             }
             // When using Apache's ProxyPass directive you might end up with
             // double slashes, which might cause endless loops. Remove those.
             $newRequestArray['REQUEST_URI'] = $this->stripExtraPathSlashes($newRequestArray['REQUEST_URI']);
+            // Align PATH_INFO with subpath to ensure correct URL generation.
+            if (isset($newRequestArray['PATH_INFO'])) {
+              if (strpos($newRequestArray['PATH_INFO'], "/{$subpath}") !== 0) {
+                $newRequestArray['PATH_INFO'] = "/{$subpath}" . $newRequestArray['PATH_INFO'];
+              }
+            }
+            else {
+              // Create PATH_INFO from REQUEST_URI if missing.
+              $path = parse_url($newRequestArray['REQUEST_URI'], PHP_URL_PATH);
+              if ($path && strpos($path, "/{$subpath}") !== 0) {
+                $newRequestArray['PATH_INFO'] = "/{$subpath}" . $path;
+              }
+            }
+            // End of PATH_INFO alignment.
             if (!str_contains((string) $newRequestArray['SCRIPT_FILENAME'], "/{$subpath}/")) {
               $newRequestArray['SCRIPT_FILENAME'] = \dirname((string) $newRequestArray['SCRIPT_FILENAME']) . "/{$subpath}/" . \basename((string) $newRequestArray['SCRIPT_FILENAME']);
             }


### PR DESCRIPTION
### Summary

Fixes incorrect URL generation when a country subpath overlaps with the beginning of the path or language prefix (e.g.` /id` and `id-id,` or `/br` and brand). The update ensures the subpath is consistently preserved in generated URLs by improving prefix detection and aligning internal request path handling.

---

### Related
**Fixes** - [Issue #43](https://github.com/pantheon-systems/pantheon_domain_masking/issues/43)
- Addresses incorrect subpath handling when prefix overlaps with path or language code
- Resolves both multilingual and single-language edge cases related to subpath detection

---

### Problem

In setups using subpath-based routing, when the country subpath shares the same starting characters as the next path segment (e.g. `/id `with `id-id`, or `/br `with `brand`), the existing logic incorrectly assumes the subpath is already present due to partial string matching.

This leads to:

- URLs being generated without the required subpath
  - `/id-id` instead of `/id/id-id`
  - `/brand `instead of `/br/brand`

- Broken links and 404 errors

The issue occurs because:

- Prefix detection relies on partial matching (`/id` matches `/id-id`)
- Internal request path (`PATH_INFO`) is not consistently aligned with the modified URI

---

### Changes

**1. Improved subpath detection logic**

- Updated condition to check for exact subpath prefix (`/xx/`) or exact match (`/xx`)
- Prevents false positives when path starts with similar characters (e.g. `id-id`, `brand`)

**2. Aligned PATH_INFO with subpath**

- Ensures internal request path used by routing matches the modified URI
- Adds subpath to `PATH_INFO` if missing
- Creates `PATH_INFO` from `REQUEST_URI` when not present

**3. Minimal and safe implementation**

- No changes to routing layer or external services
- No assumptions about language patterns
- Works dynamically for all configured subpaths

---

### Testing / Test Plan

- Verify `/xx/en-xx/...` and `/xx/xx-xx/...` return correct responses.
- Verify URLs like `/xx/xx-xx `and `/yy/`path (e.g. `/br/brand`) retain subpath correctly.
- Verify other masked domains are not affected.
- Verify assets and general routing behave as expected

---

### Verification Note

This has been tested in both multilingual and single-language setups, including overlapping prefix cases, and worked as expected without any regression.