### PR TITLE
[SITE-5207] PHP 8.5 compatibility, drop Drupal 9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,11 @@ permissions:
 
 jobs:
   linting:
-    name: Code linting
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        php-version: ["8.1", "8.5"]
+    name: Code linting (PHP ${{ matrix.php-version }})
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -16,13 +18,22 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # 2.35.4
         with:
-          php-version: '8.3'
+          php-version: ${{ matrix.php-version }}
 
       - name: Composer install
-        run: composer install
+        run: composer install --ignore-platform-reqs
 
       - name: Code sniff
         run: composer run-script codesniff
 
       - name: Code lint
         run: composer run-script code:lint
+
+  phpcompatibility:
+    runs-on: ubuntu-latest
+    name: PHP Compatibility
+    steps:
+      - name: PHPCompatibility
+        uses: pantheon-systems/phpcompatibility-action@44be5a8381691b9a209404a3f45df8254f1ce08f # v1.1.2
+        with:
+          test-versions: 8.1-

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,9 @@
         "issues": "https://github.com/pantheon-systems/pantheon_domain_masking/issues",
         "source": "https://github.com/pantheon-systems/pantheon_domain_masking"
     },
-    "require": {},
+    "require": {
+        "php": ">=8.1"
+    },
     "require-dev": {
         "drupal/coder": "^8.3",
         "squizlabs/php_codesniffer": "^3.4"

--- a/pantheon_domain_masking.info.yml
+++ b/pantheon_domain_masking.info.yml
@@ -1,6 +1,6 @@
 name: 'Pantheon Domain Masking'
 type: module
 description: 'Support for domain masking on Pantheon sites'
-core_version_requirement: ^9.4 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 package: 'Pantheon'
 configure: pantheon_domain_masking.domain_masking_config_form


### PR DESCRIPTION
## Summary

- Add PHP >=8.1 requirement to composer.json
- Drop Drupal 9.4 from core_version_requirement (EOL on Pantheon)
- Add linting matrix for PHP 8.1 and 8.5
- Add PHPCompatibility check (8.1+)

## Context

[SITE-5207](https://getpantheon.atlassian.net/browse/SITE-5207)

PHPCompatibility 10 scan found zero PHP 8.5 deprecation issues across all 4 module files. No code changes needed.

## Test plan

- [x] CI linting passes on PHP 8.1 and 8.5
- [x] PHPCompatibility check passes


[SITE-5207]: https://getpantheon.atlassian.net/browse/SITE-5207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ