### PR TITLE
chore(DELENG-769): remove duplicate root-level CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Managed by github-terraform — do not edit manually
+* @pantheon-systems/professional-services

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: Pantheon Domain Masking
+on:
+  push:
+permissions:
+  contents: read
+
+jobs:
+  linting:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ["8.1", "8.5"]
+    name: Code linting (PHP ${{ matrix.php-version }})
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # 2.35.4
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - name: Composer install
+        run: composer install --ignore-platform-reqs
+
+      - name: Code sniff
+        run: composer run-script codesniff
+
+      - name: Code lint
+        run: composer run-script code:lint
+
+  phpcompatibility:
+    runs-on: ubuntu-latest
+    name: PHP Compatibility
+    steps:
+      - name: PHPCompatibility
+        uses: pantheon-systems/phpcompatibility-action@44be5a8381691b9a209404a3f45df8254f1ce08f # v1.1.2
+        with:
+          test-versions: 8.1-

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+/composer.lock

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,340 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# Pantheon Domain Masking
+
+[![Unofficial](https://img.shields.io/badge/Pantheon-Unofficial-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#unofficial)
+
+This module allows domain masking in Drupal for environments where Drupal is not running under Apache, or where the hosting configuration is unavailable.
+
+Typically domain masking can be facilitated by adding a few lines to a `.htaccess` or `nginx.conf` file; however, if that method is unavailable, this module allows Drupal to be aware of changes to the host and to persist those changes when generating redirects.
+
+## Installing the module
+
+The module can be installed by downloading this module and placing directly in `modules/contrib` (or wherever you have decided to store modules in your filesystem). You can also [install via composer](https://getcomposer.org/doc/05-repositories.md#loading-a-package-from-a-vcs-repository) by running:
+
+```
+composer require pantheon-systems/pantheon_domain_masking
+```
+
+## Enabling and Configuring the module
+
+Once the module has been installed to the filesystem, it can be enabled like any other contrib module. However, this will not enable the domain masking functionality. Once the module is active, the config page for the module (`/admin/config/pantheon-domain-masking/options`) will allow you to enter the public-facing domain name. You will need to toggle the `Enable domain masking?` field on this page to enable the middleware.
+
+Alternatively, you may configure the module in your `settings.php` file (or another file imported by `settings.php`) by using Drupal's [Configuration Override System](https://www.drupal.org/docs/drupal-apis/configuration-api/configuration-override-system). Specify values in `settings.php` like this:
+
+```
+$config['pantheon_domain_masking.settings']['domain'] = 'foo.com';
+$config['pantheon_domain_masking.settings']['subpath'] = 'bar';
+```
+
+When you load [the configuration page](/admin/config/pantheon-domain-masking/options) you'll find that the options you set in `settings.php` appear in the form and that the form inputs are disabled.
+
+### Available Config Overrides
+
+* `domain`: The public facing domain.
+* `subpath`: The subpath for Drupal. DO NOT include the leading `/`.
+* `allow_platform`: Allow platform access.
+
+### Cache Context
+
+If `allow_platform` is enabled, you will need to add `url.site` in `renderer.config.required_cache_context` (located in `sites/default/services.yml`) to prevent cache primed in platform domain to be served in public facing domain and vice versa.
+
+```
+  renderer.config:
+    # Renderer required cache contexts:
+    #
+    # The Renderer will automatically associate these cache contexts with every
+    # render array, hence varying every render array by these cache contexts.
+    #
+    # @default ['languages:language_interface', 'theme', 'user.permissions']
+    required_cache_contexts: ['url.site', 'languages:language_interface', 'theme', 'user.permissions']
+```
+
+### Example
+
+Assume a site is running on Pantheon with a live environment address of `https://live-example.pantheonsite.io`. Assume the public-facing domain you wish to use is `https://www.example.com`. In this case, you would enter `www.example.com` in the `Public-facing domain:` field. Once the `Enable domain masking?` field is set to `Yes`, Drupal will use `www.example.com` in generating any internal redirects.
+
+## Allowing platform access
+
+Under normal circumstances, this module will force all requests to use the masked domain. However, if you wish to access this site via Pantheon's platform domain (ending in `.pantheonsite.io`) without going through the masked domain, set the `Allow Platform domain access?` field to `Yes`.
+
+### Example
+
+Following the example above, suppose the public-facing domain was masking two different Pantheon environments, eg. `https://live-example-a.pantheonsite.io` and `https://live-example-b.pantheonsite.io`. Navigating to `https://www.example.com/user/login` would resolve to whatever backend the edge server chose for that request and, depending on the configuration (eg. round-robin) may not be consistent from request to request. In order to manage both the `A` and `B` sites directly, the `Allow Platform domain access?` field would need to be set to `Yes` on both sites, and content managers would need to access `https://live-example-a.pantheonsite.io/user/login` or `https://live-example-b.pantheonsite.io/user/login` directly to manage those specific instances.

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: pantheon_domain_masking
+  description: Domain Masking helper module for D8+
+  annotations:
+    github.com/project-slug: pantheon-systems/pantheon_domain_masking
+spec:
+  type: service
+  lifecycle: production
+  owner: implementation-team

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "pantheon-systems/pantheon_domain_masking",
+    "type": "drupal-module",
+    "description": "Domain masking middleware for Drupal",
+    "keywords": ["Drupal"],
+    "license": "GPL-2.0+",
+    "version": "2.1.1",
+    "homepage": "https://github.com/pantheon-systems/pantheon_domain_masking",
+    "minimum-stability": "stable",
+    "support": {
+        "issues": "https://github.com/pantheon-systems/pantheon_domain_masking/issues",
+        "source": "https://github.com/pantheon-systems/pantheon_domain_masking"
+    },
+    "require": {
+        "php": ">=8.1"
+    },
+    "require-dev": {
+        "drupal/coder": "^8.3",
+        "squizlabs/php_codesniffer": "^3.4"
+    },
+    "scripts": {
+        "codesniff": [
+            "phpcs --report=full --extensions=php,module,inc,theme,info,install --standard=vendor/drupal/coder/coder_sniffer/Drupal src",
+            "phpcs --report=full --extensions=php,module,inc,theme,info,install --standard=vendor/drupal/coder/coder_sniffer/DrupalPractice src"
+        ],
+        "code:fix": [
+            "phpcbf --report=full --extensions=php,module,inc,theme,info,install --standard=vendor/drupal/coder/coder_sniffer/Drupal src",
+            "phpcbf --report=full --extensions=php,module,inc,theme,info,install --standard=vendor/drupal/coder/coder_sniffer/DrupalPractice src"
+        ],
+        "code:lint": "find src -name '*.php' -print0 | xargs -0 -n1 php -l"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
+}

--- a/config/install/pantheon_domain_masking.settings.yml
+++ b/config/install/pantheon_domain_masking.settings.yml
@@ -1,0 +1,4 @@
+domain: "example.com"
+enabled: 'no'
+allow_platform: 'yes'
+subpath: ''

--- a/pantheon_domain_masking.info.yml
+++ b/pantheon_domain_masking.info.yml
@@ -1,0 +1,6 @@
+name: 'Pantheon Domain Masking'
+type: module
+description: 'Support for domain masking on Pantheon sites'
+core_version_requirement: ^10 || ^11
+package: 'Pantheon'
+configure: pantheon_domain_masking.domain_masking_config_form

--- a/pantheon_domain_masking.links.menu.yml
+++ b/pantheon_domain_masking.links.menu.yml
@@ -1,0 +1,13 @@
+pantheon_domain_masking.admin_landing_page:
+  route_name: pantheon_domain_masking.admin_landing_page
+  parent: system.admin_config
+  title: 'Pantheon Domain Masking Options'
+  description: 'Configure the Pantheon Domain Masking module'
+  weight: 100
+
+pantheon_domain_masking.domain_masking_config_form:
+  title: 'Options'
+  route_name: pantheon_domain_masking.domain_masking_config_form
+  description: 'Options for Domain Masking module'
+  parent: pantheon_domain_masking.admin_landing_page
+  weight: 0

--- a/pantheon_domain_masking.module
+++ b/pantheon_domain_masking.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains pantheon_domain_masking.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function pantheon_domain_masking_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the pantheon_domain_masking module.
+    case 'help.page.pantheon_domain_masking':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Support for domain masking on Pantheon sites') . '</p>';
+      return $output;
+
+    default:
+  }
+}

--- a/pantheon_domain_masking.routing.yml
+++ b/pantheon_domain_masking.routing.yml
@@ -1,0 +1,19 @@
+pantheon_domain_masking.admin_landing_page:
+  path: 'admin/config/pantheon-domain-masking'
+  defaults:
+    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
+    _title: 'Pantheon Domain Masking Options'
+  requirements:
+    _permission: 'administer site configuration'
+  options:
+    _admin_route: TRUE
+
+pantheon_domain_masking.domain_masking_config_form:
+  path: 'admin/config/pantheon-domain-masking/options'
+  defaults:
+    _form: '\Drupal\pantheon_domain_masking\Form\DomainMaskingConfigForm'
+    _title: 'Pantheon Domain Masking Options'
+  requirements:
+    _permission: 'administer site configuration'
+  options:
+    _admin_route: TRUE

--- a/pantheon_domain_masking.services.yml
+++ b/pantheon_domain_masking.services.yml
@@ -1,0 +1,9 @@
+services:
+  pantheon_domain_masking.middleware:
+    class: Drupal\pantheon_domain_masking\Middleware\DomainMaskingMiddleware
+    arguments: ['@config.factory']
+    tags:
+      - { name: http_middleware, priority: 400 }
+  pantheon_domain_masking.helper:
+    class: Drupal\pantheon_domain_masking\Helper
+    arguments: ['@config.factory', '@request_stack']

--- a/src/Form/DomainMaskingConfigForm.php
+++ b/src/Form/DomainMaskingConfigForm.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Drupal\pantheon_domain_masking\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class DomainMaskingConfigForm.
+ *
+ * Provides a configuration form for the Domain Masking module.
+ */
+class DomainMaskingConfigForm extends ConfigFormBase {
+
+  /**
+   * Drupal\Core\Config\ConfigFactoryInterface definition.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a new DomainMaskingConfigForm object.
+   *
+   * Note:
+   * From Drupal 10.2+, ConfigFormBase::__construct() accepts an optional
+   * TypedConfigManagerInterface argument. This argument is required as of
+   * Drupal 11.
+   * In Drupal 9, ConfigFormBase::__construct() accepts only a single argument:
+   * ConfigFactoryInterface.
+   *
+   * @see https://www.drupal.org/node/3404140
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, TypedConfigManagerInterface $typed_config) {
+    parent::__construct($config_factory, $typed_config);
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  #[\Override]
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('config.typed'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'pantheon_domain_masking.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'domain_masking_config_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  #[\Override]
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $configEditable = $this->config('pantheon_domain_masking.settings');
+    $configOverridden = $this->configFactory->get('pantheon_domain_masking.settings');
+
+    $form['enabled'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Enable domain masking?'),
+      '#description' => $this->t('Once the module is enabled, all requests will pass through this middleware. Use this to toggle the middleware on and off while configuring the domain.'),
+      '#options' => [
+        'yes' => $this->t('Enabled'),
+        'no' => $this->t('Disabled'),
+      ],
+      '#default_value' => $configEditable->get('enabled'),
+    ];
+    // Check overrides.
+    if ($configEditable->get('enabled') !== $configOverridden->get('enabled')) {
+      $form['enabled']['#disabled'] = TRUE;
+      $form['enabled']['#description'] .= $this->t('**This config value has been overridden in code and cannot be changed here. The value that is shown is the actual value in use.**');
+      $form['enabled']['#default_value'] = $configOverridden->get('enabled');
+    }
+
+    $form['domain'] = [
+      '#type' => 'textfield',
+      '#length' => 255,
+      '#title' => $this->t('Public-facing domain:'),
+      '#description' => $this->t('The public-facing domain name this site will respond to. Do not include the scheme.'),
+      '#default_value' => $configEditable->get('domain'),
+    ];
+    // Check overrides.
+    if ($configEditable->get('domain') !== $configOverridden->get('domain')) {
+      $form['domain']['#disabled'] = TRUE;
+      $form['domain']['#description'] .= $this->t('**This config value has been overridden in code and cannot be changed here. The value that is shown is the actual value in use.**');
+      $form['domain']['#default_value'] = $configOverridden->get('domain');
+    }
+
+    $form['subpath'] = [
+      '#type' => 'textfield',
+      '#length' => 255,
+      '#title' => $this->t('Subpath (optional):'),
+      '#description' => $this->t('The path under the root ("/") for this site. Generally only used if this is the second website being masked on an interior path, eg. "masked.domain/blog".'),
+      '#default_value' => $configEditable->get('subpath'),
+    ];
+    // Check overrides.
+    if ($configEditable->get('subpath') !== $configOverridden->get('subpath')) {
+      $form['subpath']['#disabled'] = TRUE;
+      $form['subpath']['#description'] .= $this->t('**This config value has been overridden in code and cannot be changed here. The value that is shown is the actual value in use.**');
+      $form['subpath']['#default_value'] = $configOverridden->get('subpath');
+    }
+
+    $pantheonEnv = $_ENV['PANTHEON_ENVIRONMENT'] ?? '[env]';
+    $pantheonSiteName = $_ENV['PANTHEON_SITE_NAME'] ?? '[site-name]';
+    $form['allow_platform'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Allow Platform domain access?'),
+      '#description' => $this->t('Enable this option to allow un-masked access to %url.', [
+        '%url' => $pantheonEnv . '-' . $pantheonSiteName . '.pantheonsite.io',
+      ]),
+      '#options' => [
+        'yes' => $this->t('Allow'),
+        'no' => $this->t('Do not allow'),
+      ],
+      '#default_value' => $configEditable->get('allow_platform'),
+    ];
+    // Check overrides.
+    if ($configEditable->get('allow_platform') !== $configOverridden->get('allow_platform')) {
+      $form['allow_platform']['#disabled'] = TRUE;
+      $form['allow_platform']['#description'] .= $this->t('**This config value has been overridden in code and cannot be changed here. The value that is shown is the actual value in use.**');
+      $form['allow_platform']['#default_value'] = $configOverridden->get('allow_platform');
+    }
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  #[\Override]
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+
+    $host = $this->validateHost($form_state->getValue('domain'));
+    if ($host === FALSE) {
+      $form_state->setErrorByName('domain', $this->t('Invalid domain specified.'));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  #[\Override]
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    // Get the normalized host value.
+    $host = $this->validateHost($form_state->getValue('domain'));
+
+    $this->config('pantheon_domain_masking.settings')
+      ->set('domain', $host)
+      ->set('subpath', $form_state->getValue('subpath', NULL))
+      ->set('enabled', $form_state->getValue('enabled'))
+      ->set('allow_platform', $form_state->getValue('allow_platform'))
+      ->save();
+  }
+
+  /**
+   * Validate that the user passed a correct host value.
+   *
+   * @param string $userInput
+   *   The input from the user.
+   *
+   * @return string|bool
+   *   The validated host if available, or FALSE if the input is invalid.
+   */
+  public function validateHost($userInput) {
+    // To make sure this works properly with parse_url, tack on a scheme.
+    if (!str_contains($userInput, '://')) {
+      $userInput = 'http://' . $userInput;
+    }
+
+    $parsed = \parse_url($userInput);
+    if (!isset($parsed['host'])) {
+      return FALSE;
+    }
+
+    $return = $parsed['host'];
+
+    // Check if a port is included.
+    if (isset($parsed['port'])) {
+      $return .= ':' . $parsed['port'];
+    }
+
+    return $return;
+  }
+
+}

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\pantheon_domain_masking;
+
+use Drupal\Core\Config\ConfigFactory;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class DomainMaskingConfigForm.
+ */
+class Helper {
+
+  /**
+   * The site settings.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+  /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ConfigFactory $config_factory, RequestStack $request_stack) {
+    $this->configFactory = $config_factory;
+    $this->requestStack = $request_stack;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('request_stack')
+    );
+  }
+
+  /**
+   * Determine whether the request is coming from a platform domain.
+   *
+   * @return bool
+   *   TRUE if the request is from a platform domain; FALSE otherwise.
+   */
+  public function isPlatformDomainRequest() {
+    $req = $this->requestStack->getCurrentRequest();
+    if ($req->headers->has('adv-cdn-origin') && $req->headers->get('adv-cdn-origin', '0') == 1) {
+      return FALSE;
+    }
+    else {
+      return TRUE;
+    }
+  }
+
+  /**
+   * Should the masking be enabled for this request?
+   *
+   * @return bool
+   *   TRUE if masking should be applied; FALSE otherwise.
+   */
+  public function shouldMask() {
+    $config = $this->configFactory->get('pantheon_domain_masking.settings');
+    $mask = FALSE;
+    $enabled = \filter_var($config->get('enabled'), FILTER_VALIDATE_BOOLEAN);
+    if ($enabled === TRUE) {
+      $mask = TRUE;
+      if ($this->isPlatformDomainRequest()) {
+        $allowPlatform = \filter_var($config->get('allow_platform'), FILTER_VALIDATE_BOOLEAN);
+        if ($allowPlatform === TRUE) {
+          $mask = FALSE;
+        }
+      }
+    }
+
+    return $mask;
+  }
+
+  /**
+   * Is there a subpath in the config?
+   *
+   * @return bool
+   *   TRUE if a subpath value is present in the configuration; FALSE otherwise.
+   */
+  public function hasSubpath() {
+    return !empty($this->configFactory->get('subpath'));
+  }
+
+}

--- a/src/Middleware/DomainMaskingMiddleware.php
+++ b/src/Middleware/DomainMaskingMiddleware.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Drupal\pantheon_domain_masking\Middleware;
+
+use Drupal\Core\Config\ConfigFactory;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Class DomainMaskingMiddleware.
+ *
+ * Middleware to apply domain masking in a Drupal site.
+ */
+class DomainMaskingMiddleware implements HttpKernelInterface {
+
+  /**
+   * The decorated kernel.
+   *
+   * @var \Symfony\Component\HttpKernel\HttpKernelInterface
+   */
+  protected $httpKernel;
+
+  /**
+   * The site settings.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+  /**
+   * The original request when this middleware was first run.
+   *
+   * @var \Symfony\Component\HttpFoundation\Request
+   */
+  protected $origRequest;
+
+  /**
+   * Create a new StackOptionsRequest instance.
+   *
+   * @param \Symfony\Component\HttpKernel\HttpKernelInterface $http_kernel
+   *   The decorated kernel.
+   * @param \Drupal\Core\Config\ConfigFactory $config_factory
+   *   The site settings.
+   */
+  public function __construct(HttpKernelInterface $http_kernel, ConfigFactory $config_factory) {
+    $this->httpKernel = $http_kernel;
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function handle(Request $request, $type = 1, $catch = TRUE): Response {
+    // Type 1 is self::MAIN_REQUEST in newer Symfony versions,
+    // self::MASTER_REQUEST in older ones.
+    if (PHP_SAPI !== 'cli') {
+      $config = $this->configFactory->get('pantheon_domain_masking.settings');
+      $this->origRequest = clone $request;
+      $host = $this->origRequest->headers->get('host');
+
+      // First check to see if we're even enabled.
+      $enabled = \filter_var($config->get('enabled'), FILTER_VALIDATE_BOOLEAN);
+
+      if ($enabled === TRUE) {
+        $mask = TRUE;
+
+        // Set a vary header before we read custom server vars.
+        header('Vary: adv-cdn-origin', FALSE);
+
+        // If we're coming from a platform domain, and the user has chosen to
+        // allow platform domains, don't mask.
+        if ($this->isPlatformDomainRequest()) {
+          $allowPlatform = \filter_var($config->get('allow_platform'), FILTER_VALIDATE_BOOLEAN);
+          if ($allowPlatform === TRUE) {
+            $mask = FALSE;
+          }
+        }
+
+        if ($mask === TRUE) {
+          $domain = $config->get('domain');
+          $request->headers->set('host', $domain);
+
+          // Cookie jawn.
+          ini_set('session.cookie_domain', '.' . $domain);
+
+          $host = $domain;
+
+          // Can't do subpaths without domain masking.
+          $subpath = $config->get('subpath');
+          if (!empty($subpath)) {
+            // More cookie jawn.
+            ini_set('session.cookie_path', "/{$subpath}");
+
+            // Add the subpath back into the request, if not already present.
+            $newRequestArray = $request->server->all();
+            if (!str_starts_with((string) $newRequestArray['SCRIPT_NAME'], "/{$subpath}/")) {
+              $newRequestArray['SCRIPT_NAME'] = "/{$subpath}" . $newRequestArray['SCRIPT_NAME'];
+            }
+            if (!str_starts_with((string) $newRequestArray['REQUEST_URI'], "/{$subpath}")) {
+              $newRequestArray['REQUEST_URI'] = "/{$subpath}" . $newRequestArray['REQUEST_URI'];
+            }
+            // When using Apache's ProxyPass directive you might end up with
+            // double slashes, which might cause endless loops. Remove those.
+            $newRequestArray['REQUEST_URI'] = $this->stripExtraPathSlashes($newRequestArray['REQUEST_URI']);
+            if (!str_contains((string) $newRequestArray['SCRIPT_FILENAME'], "/{$subpath}/")) {
+              $newRequestArray['SCRIPT_FILENAME'] = \dirname((string) $newRequestArray['SCRIPT_FILENAME']) . "/{$subpath}/" . \basename((string) $newRequestArray['SCRIPT_FILENAME']);
+            }
+            $newRequestArray['HTTP_HOST'] = $host;
+            // Replace the request being used by this middleware.
+            $dupRequest = $request->duplicate(NULL, NULL, NULL, NULL, NULL, $newRequestArray);
+            $request = $dupRequest;
+          }
+
+          // Legacy globals.
+          $proto = 'https';
+          if (isset($_SERVER['HTTP_USER_AGENT_HTTPS']) && $_SERVER['HTTP_USER_AGENT_HTTPS'] != 'ON') {
+            $proto = 'http';
+          }
+          $base_path = "/{$subpath}";
+          $base_url = $base_root = "{$proto}://{$host}" . (empty($subpath) ? '' : "/{$subpath}");
+          $GLOBALS['base_path'] = $base_path;
+          $GLOBALS['base_url'] = $base_url;
+          $GLOBALS['base_root'] = $base_root;
+        }
+      }
+    }
+
+    return $this->httpKernel->handle($request, $type, $catch);
+  }
+
+  /**
+   * Determines whether or not the original request was to a platform domain.
+   *
+   * @return bool
+   *   TRUE if the request is to a platform domain, FALSE otherwise.
+   */
+  protected function isPlatformDomainRequest(?Request $request = NULL) {
+    $targetReq = $request ?: $this->origRequest;
+    if ($targetReq) {
+      if ($targetReq->headers->has('adv-cdn-origin') && $targetReq->headers->get('adv-cdn-origin', '0') == 1) {
+        return FALSE;
+      }
+      else {
+        return TRUE;
+      }
+    }
+    else {
+      return TRUE;
+    }
+  }
+
+  /**
+   * Cleans up extra slashes in the path.
+   *
+   * @return string
+   *   The URL after removing extra slashes from its path.
+   */
+  protected function stripExtraPathSlashes(String $url) {
+    $parts = parse_url($url);
+    // Thanks: https://www.php.net/manual/en/function.parse-url.php#106731
+    $scheme   = isset($parts['scheme']) ? $parts['scheme'] . '://' : '';
+    $host     = $parts['host'] ?? '';
+    $port     = isset($parts['port']) ? ':' . $parts['port'] : '';
+    $user     = $parts['user'] ?? '';
+    $pass     = isset($parts['pass']) ? ':' . $parts['pass'] : '';
+    $pass     = ($user || $pass) ? "$pass@" : '';
+    $path     = $parts['path'] ?? '';
+    $query    = isset($parts['query']) ? '?' . $parts['query'] : '';
+    $fragment = isset($parts['fragment']) ? '#' . $parts['fragment'] : '';
+    // Remove double slashes from the path.
+    $path = \str_replace('//', '/', $path);
+    return "$scheme$user$pass$host$port$path$query$fragment";
+  }
+
+}


### PR DESCRIPTION
Removing duplicate root-level `CODEOWNERS` file. `.github/CODEOWNERS` already exists and is the authoritative copy managed via github-terraform. GitHub precedence is `.github/CODEOWNERS` > root, so the root-level file is dead code.