### PR TITLE
chore(DELENG-769): remove duplicate root-level CODEOWNERS [skip ci]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @pantheon-systems/implementation-team


### PR DESCRIPTION
Removing duplicate root-level `CODEOWNERS` file. `.github/CODEOWNERS` already exists and is the authoritative copy managed via github-terraform. GitHub precedence is `.github/CODEOWNERS` > root, so the root-level file is redundant.